### PR TITLE
PMM-3941 Fill in gaps in sparklines time series.

### DIFF
--- a/services/analytics/profile.go
+++ b/services/analytics/profile.go
@@ -165,9 +165,8 @@ func (s *Service) GetReport(ctx context.Context, in *qanpb.ReportRequest) (*qanp
 		row.Metrics["latency"] = &qanpb.Metric{
 			Stats: stats,
 		}
-		// set TOTAL for total values instead if "any" dimension.
-		if i == 0 {
-			row.Dimension = ""
+		// set TOTAL for Fingerprint instead of "any" if result is not empty.
+		if i == 0 && row.Fingerprint != "" {
 			row.Fingerprint = "TOTAL"
 		}
 


### PR DESCRIPTION
... Fix broken empty result.

https://jira.percona.com/browse/PMM-3941

```bash
curl -s -X POST -d '{"period_start_from": "2019-01-01T00:00:00Z", "period_start_to": "2019-01-01T10:00:00Z", "order_by": "num_queries", "group_by": "queryid", "columns": ["query_time", "qc_hit"]}' http://127.0.0.1:9922/v1/qan/GetReport | jq ".rows[1].sparkline[14:17]"
```
An example of filled gap with empty point 15:
```json
[
  {
    "values": {
      "m_qc_hit_sum": 0,
      "m_query_load": 2.6666666e-07,
      "m_query_time_avg": 8.544726e-09,
      "m_query_time_sum": 0.00016,
      "num_queries_sum": 18725,
      "point": 14,
      "time_frame": 600,
      "timestamp": 1546328400
    }
  },
  {
    "values": {
      "point": 15,
      "time_frame": 600,
      "timestamp": 1546327800
    }
  },
  {
    "values": {
      "m_qc_hit_sum": 0,
      "m_query_load": 8.333333e-08,
      "m_query_time_avg": 6.499415e-09,
      "m_query_time_sum": 5e-05,
      "num_queries_sum": 7693,
      "point": 16,
      "time_frame": 600,
      "timestamp": 1546327200
    }
  }
]
```