### PR TITLE
PMM-4705 Fix get query example by dimensions and labels.

### DIFF
--- a/services/analytics/object_details.go
+++ b/services/analytics/object_details.go
@@ -204,6 +204,18 @@ func (s *Service) GetQueryExample(ctx context.Context, in *qanpb.QueryExampleReq
 
 	from := time.Unix(in.PeriodStartFrom.Seconds, 0)
 	to := time.Unix(in.PeriodStartTo.Seconds, 0)
+
+	labels := map[string][]string{}
+	dimensions := map[string][]string{}
+
+	for _, label := range in.GetLabels() {
+		if isDimension(label.Key) {
+			dimensions[label.Key] = label.Value
+			continue
+		}
+		labels[label.Key] = label.Value
+	}
+
 	limit := uint32(1)
 	if in.Limit > 1 {
 		limit = in.Limit
@@ -220,6 +232,8 @@ func (s *Service) GetQueryExample(ctx context.Context, in *qanpb.QueryExampleReq
 		in.FilterBy,
 		group,
 		limit,
+		dimensions,
+		labels,
 	)
 	if err != nil {
 		return nil, errors.Wrap(err, "error in selecting query examples")


### PR DESCRIPTION
https://jira.percona.com/browse/PMM-4705

FB: https://github.com/Percona-Lab/pmm-submodules/pull/477

Without query example:
<img width="1373" alt="image" src="https://user-images.githubusercontent.com/2538638/65154989-20355a00-da35-11e9-8baa-9d04c9e6ca96.png">


With query example:
<img width="1371" alt="image" src="https://user-images.githubusercontent.com/2538638/65155025-2deadf80-da35-11e9-9a55-7b421817dc86.png">