### PR TITLE
PMM-4010 Enabled Go 1.13.x in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ services:
 
 go:
   - 1.12.x
+  - 1.13.x
   # - TODO master
 
 matrix:


### PR DESCRIPTION
Ran tests locally with go 1.13.5. All tests are passing