### PR TITLE
PMM-4010 Updated travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,12 @@ matrix:
   allow_failures:
     - go: master
 
+branches:
+  except:
+    - /^PMM\-\d{4}/
+
+go_import_path: github.com/percona/qan-api2
+
 cache:
   directories:
     - /home/travis/.cache/go-build


### PR DESCRIPTION
- Added go_import_path
- Made it skip non-trunk PMM-XXXX branch builds, but still build pull requests.