### PR TITLE
Do not return non-gRPC error on zero metrics buckets.

### DIFF
--- a/models/data_ingestion.go
+++ b/models/data_ingestion.go
@@ -663,7 +663,8 @@ func (mb *MetricsBucket) insertBatch(timeout time.Duration) (err error) {
 // Save store metrics bucket received from agent into db.
 func (mb *MetricsBucket) Save(agentMsg *qanpb.CollectRequest) error {
 	if len(agentMsg.MetricsBucket) == 0 {
-		return errors.New("Nothing to save - no metrics buckets")
+		mb.l.Warnf("Nothing to save - no metrics buckets.")
+		return nil
 	}
 
 	mb.requestsCh <- agentMsg


### PR DESCRIPTION
That causes our gRPC interceptors in both qan-api2 and pmm-managed
to produce scarry-looking errors with stack traces.